### PR TITLE
Pre-release public - january 2017.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "pcl_catkin"]
 	path = pcl_catkin
 	url = git@github.com:ethz-asl/pcl_catkin.git
+[submodule "benchmark_catkin"]
+	path = benchmark_catkin
+	url = git@github.com:ethz-asl/benchmark_catkin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,80 +1,76 @@
 [submodule "protobuf_catkin"]
 	path = 3rdparty/protobuf_catkin
-	url = git@github.com:ethz-asl/protobuf_catkin.git
+	url = https://github.com/ethz-asl/protobuf_catkin.git
 [submodule "glog_catkin"]
 	path = 3rdparty/glog_catkin
-	url = git@github.com:ethz-asl/glog_catkin.git
+	url = https://github.com/ethz-asl/glog_catkin.git
 [submodule "gflags_catkin"]
 	path = 3rdparty/gflags_catkin
-	url = git@github.com:ethz-asl/gflags_catkin.git
+	url = https://github.com/ethz-asl/gflags_catkin.git
 [submodule "ceres_catkin"]
 	path = 3rdparty/ceres_catkin
-	url = git@github.com:ethz-asl/ceres_catkin.git
+	url = https://github.com/ethz-asl/ceres_catkin.git
 [submodule "suitesparse"]
 	path = 3rdparty/suitesparse
-	url = git@github.com:ethz-asl/suitesparse.git
+	url = https://github.com/ethz-asl/suitesparse.git
 [submodule "eigen_catkin"]
 	path = 3rdparty/eigen_catkin
-	url = git@github.com:ethz-asl/eigen_catkin.git
+	url = https://github.com/ethz-asl/eigen_catkin.git
 [submodule "yaml_cpp_catkin"]
 	path = 3rdparty/yaml_cpp_catkin
-	url = git@github.com:ethz-asl/yaml_cpp_catkin.git
+	url = https://github.com/ethz-asl/yaml_cpp_catkin.git
 [submodule "lpsolve_catkin"]
 	path = 3rdparty/lpsolve_catkin
-	url = git@github.com:ethz-asl/lpsolve_catkin.git
+	url = https://github.com/ethz-asl/lpsolve_catkin.git
 [submodule "metis_catkin"]
 	path = 3rdparty/metis_catkin
-	url = git@github.com:ethz-asl/metis_catkin.git
+	url = https://github.com/ethz-asl/metis_catkin.git
 [submodule "opencv3_catkin"]
 	path = 3rdparty/opencv3_catkin
-	url = git@github.com:ethz-asl/opencv3_catkin.git
+	url = https://github.com/ethz-asl/opencv3_catkin.git
 [submodule "vision_opencv"]
 	path = 3rdparty/vision_opencv
-	url = git@github.com:ethz-asl/vision_opencv.git
+	url = https://github.com/ethz-asl/vision_opencv.git
 [submodule "opengv"]
 	path = 3rdparty/opengv
-	url = git@github.com:ethz-asl/opengv.git
+	url = https://github.com/ethz-asl/opengv.git
 [submodule "doxygen_catkin"]
 	path = 3rdparty/doxygen_catkin
-	url = git@github.com:ethz-asl/doxygen_catkin.git
+	url = https://github.com/ethz-asl/doxygen_catkin.git
 [submodule "catkin_simple"]
 	path = 3rdparty/catkin_simple
-	url = git@github.com:catkin/catkin_simple.git
-
-[submodule "gurobi_catkin"]
-	path = 3rdparty_closed/gurobi_catkin
-	url = git@github.com:ethz-asl/gurobi_catkin.git
+	url = https://github.com/catkin/catkin_simple.git
 
 [submodule "voxblox"]
 	path = internal/voxblox
-	url = git@github.com:ethz-asl/voxblox.git
+	url = https://github.com/ethz-asl/voxblox.git
 [submodule "ethzasl_brisk"]
 	path = internal/ethzasl_brisk
-	url = git@github.com:ethz-asl/ethzasl_brisk.git
+	url = https://github.com/ethz-asl/ethzasl_brisk.git
 [submodule "ethzasl_apriltag2"]
 	path = internal/ethzasl_apriltag2
-	url = git@github.com:ethz-asl/ethzasl_apriltag2.git
+	url = https://github.com/ethz-asl/ethzasl_apriltag2.git
 [submodule "eigen_checks"]
 	path = internal/eigen_checks
-	url = git@github.com:ethz-asl/eigen_checks.git
+	url = https://github.com/ethz-asl/eigen_checks.git
 [submodule "libnabo"]
 	path = internal/libnabo
-	url = git@github.com:ethz-asl/libnabo.git
+	url = https://github.com/ethz-asl/libnabo.git
 [submodule "minkindr"]
 	path = internal/minkindr
-	url = git@github.com:ethz-asl/minkindr.git
+	url = https://github.com/ethz-asl/minkindr.git
 [submodule "minkindr_ros"]
 	path = internal/minkindr_ros
-	url = git@github.com:ethz-asl/minkindr_ros.git
+	url = https://github.com/ethz-asl/minkindr_ros.git
 [submodule "maplab_rovio"]
 	path = internal/maplab_rovio
-	url = git@github.com:ethz-asl/maplab_rovio.git
+	url = https://github.com/ethz-asl/maplab_rovio.git
 [submodule "kindr"]
 	path = internal/kindr
-	url = git@github.com:ethz-asl/kindr.git
+	url = https://github.com/ethz-asl/kindr.git
 [submodule "internal/plotty"]
 	path = internal/plotty
-	url = git@github.com:ethz-asl/plotty.git
+	url = https://github.com/ethz-asl/plotty.git
 [submodule "internal/hand_eye_calibration"]
 	path = internal/hand_eye_calibration
-	url = git@github.com:ethz-asl/hand_eye_calibration.git
+	url = https://github.com/ethz-asl/hand_eye_calibration.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -105,3 +105,6 @@
 [submodule "evaluation_tools"]
 	path = internal/evaluation_tools
 	url = git@github.com:ethz-asl/evaluation_tools.git
+[submodule "internal/fw_gtsam_extensions"]
+	path = internal/fw_gtsam_extensions
+	url = git@github.com:ethz-asl/fw_gtsam_extensions.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -90,9 +90,6 @@
 [submodule "volumetric_mapping"]
 	path = internal/volumetric_mapping
 	url = git@github.com:ethz-asl/volumetric_mapping.git
-[submodule "mono_dense_reconstruction"]
-	path = internal/mono_dense_reconstruction
-	url = git@github.com:ethz-asl/mono_dense_reconstruction.git
 [submodule "maplab_rovio"]
 	path = internal/maplab_rovio
 	url = git@github.com:ethz-asl/maplab_rovio.git
@@ -105,6 +102,9 @@
 [submodule "evaluation_tools"]
 	path = internal/evaluation_tools
 	url = git@github.com:ethz-asl/evaluation_tools.git
-[submodule "internal/fw_gtsam_extensions"]
+[submodule "fw_gtsam_extensions"]
 	path = internal/fw_gtsam_extensions
 	url = git@github.com:ethz-asl/fw_gtsam_extensions.git
+[submodule "open_mono_dense_reconstruction"]
+	path = internal/open_mono_dense_reconstruction
+	url = git@github.com:ethz-asl/open_mono_dense_reconstruction.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -72,9 +72,6 @@
 [submodule "kindr"]
 	path = internal/kindr
 	url = git@github.com:ethz-asl/kindr.git
-[submodule "open_mono_dense_reconstruction"]
-	path = internal/open_mono_dense_reconstruction
-	url = git@github.com:ethz-asl/open_mono_dense_reconstruction.git
 [submodule "internal/plotty"]
 	path = internal/plotty
 	url = git@github.com:ethz-asl/plotty.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,12 +40,6 @@
 [submodule "metis_catkin"]
 	path = metis_catkin
 	url = git@github.com:ethz-asl/metis_catkin.git
-[submodule "openvdb_catkin"]
-	path = openvdb_catkin
-	url = git@github.com:ethz-asl/openvdb_catkin.git
-[submodule "cmvs_pmvs_catkin"]
-	path = cmvs_pmvs_catkin
-	url = git@github.com:ethz-asl/cmvs_pmvs_catkin.git
 [submodule "opencv3_catkin"]
 	path = opencv3_catkin
 	url = git@github.com:ethz-asl/opencv3_catkin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,24 +13,12 @@
 [submodule "suitesparse"]
 	path = 3rdparty/suitesparse
 	url = git@github.com:ethz-asl/suitesparse.git
-[submodule "zeromq_catkin"]
-	path = 3rdparty/zeromq_catkin
-	url = git@github.com:ethz-asl/zeromq_catkin.git
 [submodule "eigen_catkin"]
 	path = 3rdparty/eigen_catkin
 	url = git@github.com:ethz-asl/eigen_catkin.git
 [submodule "yaml_cpp_catkin"]
 	path = 3rdparty/yaml_cpp_catkin
 	url = git@github.com:ethz-asl/yaml_cpp_catkin.git
-[submodule "sparsehash_catkin"]
-	path = 3rdparty/sparsehash_catkin
-	url = git@github.com:ethz-asl/sparsehash_catkin.git
-[submodule "nlopt"]
-	path = 3rdparty/nlopt
-	url = git@github.com:ethz-asl/nlopt.git
-[submodule "gtsam_catkin"]
-	path = 3rdparty/gtsam_catkin
-	url = git@github.com:ethz-asl/gtsam_catkin.git
 [submodule "lpsolve_catkin"]
 	path = 3rdparty/lpsolve_catkin
 	url = git@github.com:ethz-asl/lpsolve_catkin.git
@@ -43,12 +31,6 @@
 [submodule "vision_opencv"]
 	path = 3rdparty/vision_opencv
 	url = git@github.com:ethz-asl/vision_opencv.git
-[submodule "benchmark_catkin"]
-	path = 3rdparty/benchmark_catkin
-	url = git@github.com:ethz-asl/benchmark_catkin.git
-[submodule "gps_umd"]
-	path = 3rdparty/gps_umd
-	url = git@github.com:ethz-asl/gps_umd.git
 [submodule "opengv"]
 	path = 3rdparty/opengv
 	url = git@github.com:ethz-asl/opengv.git
@@ -84,21 +66,12 @@
 [submodule "minkindr_ros"]
 	path = internal/minkindr_ros
 	url = git@github.com:ethz-asl/minkindr_ros.git
-[submodule "volumetric_mapping"]
-	path = internal/volumetric_mapping
-	url = git@github.com:ethz-asl/volumetric_mapping.git
 [submodule "maplab_rovio"]
 	path = internal/maplab_rovio
 	url = git@github.com:ethz-asl/maplab_rovio.git
 [submodule "kindr"]
 	path = internal/kindr
 	url = git@github.com:ethz-asl/kindr.git
-[submodule "evaluation_tools"]
-	path = internal/evaluation_tools
-	url = git@github.com:ethz-asl/evaluation_tools.git
-[submodule "fw_gtsam_extensions"]
-	path = internal/fw_gtsam_extensions
-	url = git@github.com:ethz-asl/fw_gtsam_extensions.git
 [submodule "open_mono_dense_reconstruction"]
 	path = internal/open_mono_dense_reconstruction
 	url = git@github.com:ethz-asl/open_mono_dense_reconstruction.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,15 +13,6 @@
 [submodule "suitesparse"]
 	path = suitesparse
 	url = git@github.com:ethz-asl/suitesparse.git
-[submodule "catkin_zeromq"]
-	path = catkin_zeromq
-	url = git@github.com:ethz-asl/catkin_zeromq.git
-[submodule "catkin_poco"]
-	path = catkin_poco
-	url = git@github.com:ethz-asl/catkin_poco.git
-[submodule "poco_catkin"]
-	path = poco_catkin
-	url = git@github.com:ethz-asl/poco_catkin.git
 [submodule "zeromq_catkin"]
 	path = zeromq_catkin
 	url = git@github.com:ethz-asl/zeromq_catkin.git
@@ -67,3 +58,6 @@
 [submodule "benchmark_catkin"]
 	path = benchmark_catkin
 	url = git@github.com:ethz-asl/benchmark_catkin.git
+[submodule "gps_umd"]
+	path = gps_umd
+	url = git@github.com:ethz-asl/gps_umd.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -102,3 +102,6 @@
 [submodule "open_mono_dense_reconstruction"]
 	path = internal/open_mono_dense_reconstruction
 	url = git@github.com:ethz-asl/open_mono_dense_reconstruction.git
+[submodule "internal/plotty"]
+	path = internal/plotty
+	url = git@github.com:ethz-asl/plotty.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,57 +1,104 @@
 [submodule "protobuf_catkin"]
-	path = protobuf_catkin
+	path = 3rdparty/protobuf_catkin
 	url = git@github.com:ethz-asl/protobuf_catkin.git
 [submodule "glog_catkin"]
-	path = glog_catkin
+	path = 3rdparty/glog_catkin
 	url = git@github.com:ethz-asl/glog_catkin.git
 [submodule "gflags_catkin"]
-	path = gflags_catkin
+	path = 3rdparty/gflags_catkin
 	url = git@github.com:ethz-asl/gflags_catkin.git
 [submodule "ceres_catkin"]
-	path = ceres_catkin
+	path = 3rdparty/ceres_catkin
 	url = git@github.com:ethz-asl/ceres_catkin.git
 [submodule "suitesparse"]
-	path = suitesparse
+	path = 3rdparty/suitesparse
 	url = git@github.com:ethz-asl/suitesparse.git
 [submodule "zeromq_catkin"]
-	path = zeromq_catkin
+	path = 3rdparty/zeromq_catkin
 	url = git@github.com:ethz-asl/zeromq_catkin.git
 [submodule "eigen_catkin"]
-	path = eigen_catkin
+	path = 3rdparty/eigen_catkin
 	url = git@github.com:ethz-asl/eigen_catkin.git
 [submodule "yaml_cpp_catkin"]
-	path = yaml_cpp_catkin
+	path = 3rdparty/yaml_cpp_catkin
 	url = git@github.com:ethz-asl/yaml_cpp_catkin.git
 [submodule "sparsehash_catkin"]
-	path = sparsehash_catkin
+	path = 3rdparty/sparsehash_catkin
 	url = git@github.com:ethz-asl/sparsehash_catkin.git
-[submodule "stxxl_catkin"]
-	path = stxxl_catkin
-	url = git@github.com:ethz-asl/stxxl_catkin.git
 [submodule "nlopt"]
-	path = nlopt
+	path = 3rdparty/nlopt
 	url = git@github.com:ethz-asl/nlopt.git
 [submodule "gtsam_catkin"]
-	path = gtsam_catkin
+	path = 3rdparty/gtsam_catkin
 	url = git@github.com:ethz-asl/gtsam_catkin.git
 [submodule "lpsolve_catkin"]
-	path = lpsolve_catkin
+	path = 3rdparty/lpsolve_catkin
 	url = git@github.com:ethz-asl/lpsolve_catkin.git
 [submodule "metis_catkin"]
-	path = metis_catkin
+	path = 3rdparty/metis_catkin
 	url = git@github.com:ethz-asl/metis_catkin.git
 [submodule "opencv3_catkin"]
-	path = opencv3_catkin
+	path = 3rdparty/opencv3_catkin
 	url = git@github.com:ethz-asl/opencv3_catkin.git
 [submodule "vision_opencv"]
-	path = vision_opencv
+	path = 3rdparty/vision_opencv
 	url = git@github.com:ethz-asl/vision_opencv.git
 [submodule "pcl_catkin"]
-	path = pcl_catkin
+	path = 3rdparty/pcl_catkin
 	url = git@github.com:ethz-asl/pcl_catkin.git
 [submodule "benchmark_catkin"]
-	path = benchmark_catkin
+	path = 3rdparty/benchmark_catkin
 	url = git@github.com:ethz-asl/benchmark_catkin.git
 [submodule "gps_umd"]
-	path = gps_umd
+	path = 3rdparty/gps_umd
 	url = git@github.com:ethz-asl/gps_umd.git
+[submodule "opengv"]
+	path = 3rdparty/opengv
+	url = git@github.com:ethz-asl/opengv.git
+[submodule "doxygen_catkin"]
+	path = 3rdparty/doxygen_catkin
+	url = git@github.com:ethz-asl/doxygen_catkin.git
+[submodule "catkin_simple"]
+	path = 3rdparty/catkin_simple
+	url = git@github.com:catkin/catkin_simple.git
+
+[submodule "gurobi_catkin"]
+	path = 3rdparty_closed/gurobi_catkin
+	url = git@github.com:ethz-asl/gurobi_catkin.git
+
+[submodule "voxblox"]
+	path = internal/voxblox
+	url = git@github.com:ethz-asl/voxblox.git
+[submodule "ethzasl_brisk"]
+	path = internal/ethzasl_brisk
+	url = git@github.com:ethz-asl/ethzasl_brisk.git
+[submodule "ethzasl_apriltag2"]
+	path = internal/ethzasl_apriltag2
+	url = git@github.com:ethz-asl/ethzasl_apriltag2.git
+[submodule "eigen_checks"]
+	path = internal/eigen_checks
+	url = git@github.com:ethz-asl/eigen_checks.git
+[submodule "libnabo"]
+	path = internal/libnabo
+	url = git@github.com:ethz-asl/libnabo.git
+[submodule "minkindr"]
+	path = internal/minkindr
+	url = git@github.com:ethz-asl/minkindr.git
+[submodule "minkindr_ros"]
+	path = internal/minkindr_ros
+	url = git@github.com:ethz-asl/minkindr_ros.git
+[submodule "volumetric_mapping"]
+	path = internal/volumetric_mapping
+	url = git@github.com:ethz-asl/volumetric_mapping.git
+[submodule "mono_dense_reconstruction"]
+	path = internal/mono_dense_reconstruction
+	url = git@github.com:ethz-asl/mono_dense_reconstruction.git
+[submodule "maplab_rovio"]
+	path = internal/maplab_rovio
+	url = git@github.com:ethz-asl/maplab_rovio.git
+[submodule "maplab_lightweight_filtering"]
+	path = internal/maplab_lightweight_filtering
+	url = git@github.com:ethz-asl/maplab_lightweight_filtering.git
+[submodule "kindr"]
+	path = internal/kindr
+	url = git@github.com:ethz-asl/kindr.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -105,3 +105,6 @@
 [submodule "internal/plotty"]
 	path = internal/plotty
 	url = git@github.com:ethz-asl/plotty.git
+[submodule "internal/hand_eye_calibration"]
+	path = internal/hand_eye_calibration
+	url = git@github.com:ethz-asl/hand_eye_calibration.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -43,9 +43,6 @@
 [submodule "vision_opencv"]
 	path = 3rdparty/vision_opencv
 	url = git@github.com:ethz-asl/vision_opencv.git
-[submodule "pcl_catkin"]
-	path = 3rdparty/pcl_catkin
-	url = git@github.com:ethz-asl/pcl_catkin.git
 [submodule "benchmark_catkin"]
 	path = 3rdparty/benchmark_catkin
 	url = git@github.com:ethz-asl/benchmark_catkin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -102,3 +102,6 @@
 [submodule "kindr"]
 	path = internal/kindr
 	url = git@github.com:ethz-asl/kindr.git
+[submodule "evaluation_tools"]
+	path = internal/evaluation_tools
+	url = git@github.com:ethz-asl/evaluation_tools.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -90,9 +90,6 @@
 [submodule "maplab_rovio"]
 	path = internal/maplab_rovio
 	url = git@github.com:ethz-asl/maplab_rovio.git
-[submodule "maplab_lightweight_filtering"]
-	path = internal/maplab_lightweight_filtering
-	url = git@github.com:ethz-asl/maplab_lightweight_filtering.git
 [submodule "kindr"]
 	path = internal/kindr
 	url = git@github.com:ethz-asl/kindr.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(aslam_map_manager)
+project(maplab_dependencies)
 find_package(catkin REQUIRED)
 
 catkin_metapackage()

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ maplab_dependencies
 
 A repository holding submodules with maplab dependencies
 
-###Installation
+### Installation
 
 ```bash
 git clone --recursive git@github.com:ethz-asl/maplab_dependencies.git

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-thirdparty_submodules
-=====================
+maplab_dependencies
+===================
 
-A repository holding submodules of thirdparty repositories
+A repository holding submodules with maplab dependencies
 
 ###Installation
 
 ```bash
-git clone --recursive git@github.com:ethz-asl/thirdparty_submodules.git
+git clone --recursive git@github.com:ethz-asl/maplab_dependencies.git
 ```


### PR DESCRIPTION
Pre-release branch to push to ethz-asl/maplab (public).

- Forked from `release_public/dec-2017`.
- Merged in `devel/maplab-private`.